### PR TITLE
Change python to python3 to account for alpine image change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
       - checkout
       - run:
           name: Install Python, pip, and jq
-          command: apk add python py-pip jq
+          command: apk add python3 py-pip jq
       - run:
           name: Install AWS cli
           command: pip install awscli --user


### PR DESCRIPTION
This change was required for me to get this to work.

I believe it is due to a bump in the `circleci/python:2.7-stretch` image from alpine 3.11 to alpine 3.12

see more here https://github.com/docker-library/docker/issues/240

and here https://dev.to/gustavorglima/how-to-solve-error-unsatisfiable-constraints-python-48k7